### PR TITLE
Use Thenable instead of Promise in jsawait()

### DIFF
--- a/src/jsasync/JSAsyncTools.hx
+++ b/src/jsasync/JSAsyncTools.hx
@@ -9,7 +9,7 @@ class JSAsyncTools {
 	}
 
 	/** Awaits a JS Promise. (only valid inside an async function) */
-	public static extern inline function jsawait<T>(promise: js.lib.Promise<T>): T {
+	public static extern inline function jsawait<T>(promise: js.lib.Promise.Thenable<T>): T {
 		return js.Syntax.code("(await {0})", promise);
 	}
 }


### PR DESCRIPTION
This is necessary for some APIs that use `Thenable`, such as VSCode.