### PR TITLE
Improve `fixOutputFile()` performance.

### DIFF
--- a/src/jsasync/impl/Macro.hx
+++ b/src/jsasync/impl/Macro.hx
@@ -197,7 +197,7 @@ class Macro {
 	static function fixOutputFile() {
 		if ( Context.defined("jsasync-no-fix-pass") || Context.defined("jsasync-no-markers") || Sys.args().indexOf("--no-output") != -1 ) return;
 		var output = Compiler.getOutput();
-		
+
 		/**
 		* markerRegEx broken down:
 		* ( # Start of group 1, this will be reinserted on replacement
@@ -215,12 +215,18 @@ class Macro {
 		*                            # optional arguments will generate `if ( argument == null ) { argument = defaultValue }` between
 		*                            # the function's opening curly bracket and the %%async_marker%%
 		* ) # End of group 1
-		* %%async_marker%%; # Match the marker which will be removed in the replacement.
+		* $ # End of this string (where the marker was found)
 		*/
-		var markerRegEx = ~/((?:function )?(?:"(?:[^"\\]|\\.)*"|\w+)\s*\([^()]*\)\s*{(?:[^{}]|{[^{}]*?})*?)%%async_marker%%;/g;
+		var functionRegEx = ~/((?:function )?(?:"(?:[^"\\]|\\.)*"|\w+)\s*\([^()]*\)\s*{(?:[^{}]|{[^{}]*?})*?)$/;
 		var returnNothingRegEx = ~/\s*return %%async_nothing%%;/g;
 		var outputContent = sys.io.File.getContent(output);
-		outputContent = markerRegEx.replace(outputContent, "async $1");
+
+		var splitOutput = outputContent.split("%%async_marker%%;");
+		for ( i in 0...(splitOutput.length - 1) ) {
+			splitOutput[i] = functionRegEx.replace(splitOutput[i], "async $1");
+		}
+		outputContent = splitOutput.join("");
+
 		outputContent = returnNothingRegEx.replace(outputContent, "");
 		File.saveContent(output, outputContent);
 	}

--- a/src/jsasync/impl/Macro.hx
+++ b/src/jsasync/impl/Macro.hx
@@ -223,7 +223,11 @@ class Macro {
 
 		var splitOutput = outputContent.split("%%async_marker%%;");
 		for ( i in 0...(splitOutput.length - 1) ) {
-			splitOutput[i] = functionRegEx.replace(splitOutput[i], "async $1");
+			// functionRegEx crashes if searching too long a string
+			var cutoff = splitOutput[i].length - 3000;
+			var sub = splitOutput[i].substr(cutoff);
+			sub = functionRegEx.replace(sub, "async $1");
+			splitOutput[i] = splitOutput[i].substr(0, cutoff) + sub;
 		}
 		outputContent = splitOutput.join("");
 

--- a/src/jsasync/impl/Macro.hx
+++ b/src/jsasync/impl/Macro.hx
@@ -226,8 +226,11 @@ class Macro {
 			// functionRegEx crashes if searching too long a string
 			var cutoff = splitOutput[i].length - 3000;
 			var sub = splitOutput[i].substr(cutoff);
-			sub = functionRegEx.replace(sub, "async $1");
-			splitOutput[i] = splitOutput[i].substr(0, cutoff) + sub;
+
+			if ( functionRegEx.match(sub) ) {
+				sub = functionRegEx.matchedLeft() + "async " + functionRegEx.matched(1);
+				splitOutput[i] = splitOutput[i].substr(0, cutoff) + sub;
+			} else throw "Function arguments longer than 3000 characters.";
 		}
 		outputContent = splitOutput.join("");
 


### PR DESCRIPTION
I found that `fixOutputFile()` would crash on large JS files (such as a basic Lime project), specifically due to `markerRegEx`. Even after massively simplifying, it still took 20+ seconds to finish, and had more potential for mistakes.

Meanwhile `returnNothingRegEx` ran in a fraction of a second.

My best guess is, the problem happens because it always starts from the front of the regex. There are a _lot_ of functions in a JS file, not to mention several things (`if`, `for`, `while`, etc.) that look like functions at first glance. Starting at the beginning of the regex, you'll have to parse every single one of those.

I don't know how to tell Haxe to start from the end of a regex, so I did the next best thing. Do my own search for `%%async_marker%%`, then run the regex in that vicinity. Specifically, I used `split()`, and then added the `$` character to the regex.

~~Edit: Do not merge, I tested incorrectly and this doesn't actually help.~~